### PR TITLE
Proper Routing of Installation page

### DIFF
--- a/producthunt_pro/products/templates/products/index.html
+++ b/producthunt_pro/products/templates/products/index.html
@@ -54,7 +54,7 @@
   <h1 class='display-5 fw-bold lh-1 mb-3' align='center'>Don't have python in your PC?!</h1><br>
   <h5 align='center'>Check out our Python3 installation page to install Python!</h5><br>
   <p align='center'>
-  <a href="./installation.html" class="btn btn-primary btn-lg px-4 me-md-2" type="button">Installation Page</a>
+  <a href="{% url 'installpy' %}" class="btn btn-primary btn-lg px-4 me-md-2" type="button">Installation Page</a>
   </p>
   <br>
 {% endblock %}


### PR DESCRIPTION
Now, after clicking on `Installation Page` button, it now properly routes to Installation.html page

![image](https://github.com/X-Evolve/Python_Hunt/assets/94217598/63933fb0-034f-49c4-81a6-1d448514d3c9)
![image](https://github.com/X-Evolve/Python_Hunt/assets/94217598/dd9eb998-c786-4e62-872a-872337977ec7)
